### PR TITLE
KK-10956: Fix send money v2_bugs

### DIFF
--- a/lib/k2-connect-ruby/k2_entity/k2_financial_entities/destination/merchant_bank_account.rb
+++ b/lib/k2-connect-ruby/k2_entity/k2_financial_entities/destination/merchant_bank_account.rb
@@ -7,14 +7,14 @@ module K2ConnectRuby
         class MerchantBankAccount < DestinationRequest
           include ActiveModel::Validations
 
-          attr_accessor :destination_reference
+          attr_accessor :reference
 
-          validates :destination_reference, presence: true
+          validates :reference, presence: true
 
           def destination_payload
             {
               type: type,
-              reference: destination_reference,
+              reference: reference,
               amount: amount,
             }
           end

--- a/lib/k2-connect-ruby/k2_entity/k2_financial_entities/destination/merchant_mpesa_wallet.rb
+++ b/lib/k2-connect-ruby/k2_entity/k2_financial_entities/destination/merchant_mpesa_wallet.rb
@@ -7,14 +7,14 @@ module K2ConnectRuby
         class MerchantMpesaWallet < DestinationRequest
           include ActiveModel::Validations
 
-          attr_accessor :destination_reference
+          attr_accessor :reference
 
-          validates :destination_reference, presence: true
+          validates :reference, presence: true
 
           def destination_payload
             {
               type: type,
-              reference: destination_reference,
+              reference: reference,
               amount: amount,
             }
           end

--- a/lib/k2-connect-ruby/k2_entity/k2_financial_entities/send_money.rb
+++ b/lib/k2-connect-ruby/k2_entity/k2_financial_entities/send_money.rb
@@ -38,7 +38,7 @@ module K2ConnectRuby
         K2ConnectRuby::K2Entity::K2FinancialEntities::SendMoney::SendMoneyRequest.new(
           source_identifier: params[:source_identifier],
           destination_requests: build_destination_requests(params[:destinations]),
-          merchant_metadata: params[:merchant_metadata],
+          metadata: params[:metadata],
           callback_url: params[:callback_url],
         )
       end

--- a/spec/k2_tests/entity_tests/entities_spec/send_money_spec.rb
+++ b/spec/k2_tests/entity_tests/entities_spec/send_money_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             destinations: [
               {
                 type: "merchant_bank_account",
-                destination_reference: Faker::Internet.url,
+                reference: Faker::Internet.url,
                 amount: Faker::Number.number(digits: 4),
               },
             ],
@@ -644,7 +644,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             destinations: [
               {
                 type: "merchant_bank_account",
-                destination_reference: Faker::Internet.url,
+                reference: Faker::Internet.url,
                 amount: Faker::Number.number(digits: 4),
               },
             ],
@@ -668,7 +668,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
               destinations: [
                 {
                   type: "merchant_bank_account",
-                  destination_reference: nil,
+                  reference: nil,
                   amount: Faker::Number.number(digits: 4),
                 },
               ],
@@ -679,7 +679,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             access_token = K2ConnectRuby::K2Entity::K2Token.new("client_id", "client_secret").request_token
             k2pay = K2ConnectRuby::K2Entity::SendMoney.new(access_token)
             aggregate_failures do
-              expect { k2pay.create_payment(params) }.to(raise_error(ArgumentError, "Destination reference can't be blank"))
+              expect { k2pay.create_payment(params) }.to(raise_error(ArgumentError, "Reference can't be blank"))
               expect(WebMock).not_to(have_requested(:post, URI.parse(K2ConnectRuby::K2Utilities::Config::K2Config.endpoint("payments"))))
             end
           end
@@ -693,7 +693,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
               destinations: [
                 {
                   type: "merchant_bank_account",
-                  destination_reference: Faker::Internet.url,
+                  reference: Faker::Internet.url,
                   amount: Faker::Number.number(digits: 4),
                 },
               ],
@@ -721,7 +721,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             destinations: [
               {
                 type: "merchant_wallet",
-                destination_reference: Faker::Internet.url,
+                reference: Faker::Internet.url,
                 amount: Faker::Number.number(digits: 4),
               },
             ],
@@ -742,7 +742,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             destinations: [
               {
                 type: "merchant_wallet",
-                destination_reference: Faker::Internet.url,
+                reference: Faker::Internet.url,
                 amount: Faker::Number.number(digits: 4),
               },
             ],
@@ -766,7 +766,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
               destinations: [
                 {
                   type: "merchant_wallet",
-                  destination_reference: nil,
+                  reference: nil,
                   amount: Faker::Number.number(digits: 4),
                 },
               ],
@@ -777,7 +777,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
             access_token = K2ConnectRuby::K2Entity::K2Token.new("client_id", "client_secret").request_token
             k2pay = K2ConnectRuby::K2Entity::SendMoney.new(access_token)
             aggregate_failures do
-              expect { k2pay.create_payment(params) }.to(raise_error(ArgumentError, "Destination reference can't be blank"))
+              expect { k2pay.create_payment(params) }.to(raise_error(ArgumentError, "Reference can't be blank"))
               expect(WebMock).not_to(have_requested(:post, URI.parse(K2ConnectRuby::K2Utilities::Config::K2Config.endpoint("payments"))))
             end
           end
@@ -791,7 +791,7 @@ RSpec.describe(K2ConnectRuby::K2Entity::SendMoney) do
               destinations: [
                 {
                   type: "merchant_wallet",
-                  destination_reference: Faker::Internet.url,
+                  reference: Faker::Internet.url,
                   amount: Faker::Number.number(digits: 4),
                 },
               ],


### PR DESCRIPTION
This PR fixes the following send money v2 bugs:
1. Merchant metadata not being sent to core
2. Change merchant account destination_reference to reference

cc: @DavidKar1uk1 